### PR TITLE
Attempt to fix extra newlines in generated JSON

### DIFF
--- a/app/assets/javascripts/swaggard/swagger-ui.js
+++ b/app/assets/javascripts/swaggard/swagger-ui.js
@@ -1181,9 +1181,6 @@ OperationView = (function(_super) {
       this.model.isReadOnly = true;
     }
     this.model.description = this.model.description || this.model.notes;
-    //if (this.model.description) {
-    //  this.model.description = this.model.description.replace(/(?:\r\n|\r|\n)/g, '<br />');
-    //}
     this.model.oauth = null;
     modelAuths = this.model.authorizations || this.model.security;
     if (modelAuths) {

--- a/app/assets/javascripts/swaggard/swagger-ui.js
+++ b/app/assets/javascripts/swaggard/swagger-ui.js
@@ -1181,9 +1181,9 @@ OperationView = (function(_super) {
       this.model.isReadOnly = true;
     }
     this.model.description = this.model.description || this.model.notes;
-    if (this.model.description) {
-      this.model.description = this.model.description.replace(/(?:\r\n|\r|\n)/g, '<br />');
-    }
+    //if (this.model.description) {
+    //  this.model.description = this.model.description.replace(/(?:\r\n|\r|\n)/g, '<br />');
+    //}
     this.model.oauth = null;
     modelAuths = this.model.authorizations || this.model.security;
     if (modelAuths) {

--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -21,7 +21,7 @@ module Swaggard
         @summary = yard_object.docstring.lines.first || ''
         @parameters  = []
         @responses = []
-        @description = (yard_object.docstring.lines[1..-1] || []).join("\n")
+        @description = (yard_object.docstring.lines[1..-1] || []).join('')
         @formats = Swaggard.configuration.api_formats
 
         yard_object.tags.each do |yard_tag|


### PR DESCRIPTION
This attempts to resolve #2. Essentially, when Swaggard generates the JSON
file from comments containing newlines, it inserts extra newlines which cause
the Markdown compiler to treat each line as a separate paragraph. Similarly,
the Swaggard implementation of swagger-ui replaces every newline char with a
`<br />` before the Markdown compiler processes the raw text.

This commit should resolve both of these issues.
