### PR TITLE
Accept a Proc on authentication_value

### DIFF
--- a/app/controllers/swaggard/swagger_controller.rb
+++ b/app/controllers/swaggard/swagger_controller.rb
@@ -8,7 +8,9 @@ module Swaggard
         format.html do
           @authentication_type = Swaggard.configuration.authentication_type
           @authentication_key = Swaggard.configuration.authentication_key
-          @authentication_value = Swaggard.configuration.authentication_value
+          @authentication_value = Swaggard.configuration.authentication_value.respond_to?(:call) ?
+                                    Swaggard.configuration.authentication_value.call :
+                                    Swaggard.configuration.authentication_value
 
           render :index, layout: false
         end

--- a/lib/swaggard/version.rb
+++ b/lib/swaggard/version.rb
@@ -1,5 +1,5 @@
 module Swaggard
 
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 
 end


### PR DESCRIPTION
Use a proc on the authentication_value Swaggard configuration initializer. 

It solve the problem when your set a token with a value that expires in 7 days, but if rails does not restart before then - then the swagger UI will not have a valid token (it will be expired)

Example of use using [JWT](https://github.com/jwt/ruby-jwt):

```
authentication_value = Proc.new do
  jwt_secret = Rails.application.config.authentication.jwt_secret
  payload = { exp: 1.days.from_now.to_i, data: { id: 'xxx } }

  JWT.encode(payload, jwt_secret)
end

Swaggard.configure do |config|
  # ...
  config.authentication_value = authentication_value
  # ...
end
```
