### PR TITLE
Support status codes in @response_class

### DIFF
--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -37,7 +37,7 @@ module Swaggard
           when 'parameter_list'
             @parameters << Parameters::List.new(value)
           when 'response_class'
-            @responses << Response.new(200, value)
+            @responses << Response.new(value)
           end
         end
 

--- a/lib/swaggard/swagger/response.rb
+++ b/lib/swaggard/swagger/response.rb
@@ -6,8 +6,8 @@ module Swaggard
 
       attr_reader :status_code
 
-      def initialize(status_code, value)
-        @status_code = status_code
+      def initialize(value)
+        @status_code = 200
         parse(value)
       end
 
@@ -21,12 +21,16 @@ module Swaggard
       private
 
       def parse(value)
+        value, status_code = value.split(/\s/)
+
         @is_array_response = value =~ /Array/
         @response_class = if @is_array_response
                             value.match(/^Array<(.*)>$/)[1]
                           else
                             value
                           end
+
+        @status_code = status_code.to_i if status_code
       end
 
       def response_model


### PR DESCRIPTION
The default `200` status code is retained. So

    @response_class MyClass

still works as expected. When specifying a specific status code,
simply separate it with whitespace from the class.

    @response_class MyClass 201