### PR TITLE
Added ability to define custom data types.

### DIFF
--- a/lib/generators/swaggard/templates/swaggard.rb
+++ b/lib/generators/swaggard/templates/swaggard.rb
@@ -53,6 +53,10 @@ Swaggard.configure do |config|
   # Specify where to look for your controllers
   # config.controllers_path = "#{Rails.root}/app/controllers/**/*.rb"
 
+  # Set custom types to use in your Swagger definitions
+  # See https://github.com/adrian-gomez/swaggard#custom-data-types for more details
+  # config.custom_data_types = {}
+
   # Specify a default content type for requests to use in SwaggerUI.
   # See https://github.com/adrian-gomez/swaggard#default-content-type for more info
   # config.default_content_type = ""

--- a/lib/swaggard/configuration.rb
+++ b/lib/swaggard/configuration.rb
@@ -18,7 +18,7 @@ module Swaggard
                 :description, :tos, :contact_email, :contact_name, :contact_url, :host,
                 :authentication_type, :authentication_key, :authentication_value,
                 :access_username, :access_password, :default_content_type, :use_cache,
-                :language, :additional_parameters, :schemes
+                :language, :additional_parameters, :schemes, :custom_data_types
 
     def swagger_version
       @swagger_version ||= '2.0'
@@ -112,5 +112,8 @@ module Swaggard
       @use_cache ||= false
     end
 
+    def custom_data_types
+      @custom_data_types ||= {}
+    end
   end
 end

--- a/lib/swaggard/swagger/tag.rb
+++ b/lib/swaggard/swagger/tag.rb
@@ -12,7 +12,7 @@ module Swaggard
         @yard_name = yard_object.name
         @controller_class = controller_name.constantize
 
-        tag = yard_object.tags.find { |tag| tag.tag_name == 'tag' }
+        tag = yard_object.tags.find { |t| t.tag_name == 'tag' }
 
         @name =  tag ? tag.text : "#{@controller_class.controller_path}"
         @description = yard_object.docstring || ''

--- a/lib/swaggard/swagger/type.rb
+++ b/lib/swaggard/swagger/type.rb
@@ -3,18 +3,18 @@ module Swaggard
     class Type
 
       BASIC_TYPES = {
-        'integer'   => { 'type' => 'integer', 'format' => 'int32' },
-        'long'      => { 'type' => 'integer', 'format' => 'int64' },
-        'float'     => { 'type' => 'number',  'format' => 'float' },
-        'double'    => { 'type' => 'number',  'format' => 'double' },
-        'string'    => { 'type' => 'string' },
-        'byte'      => { 'type' => 'string',  'format' => 'byte' },
         'binary'    => { 'type' => 'string',  'format' => 'binary' },
         'boolean'   => { 'type' => 'boolean' },
-        'date'      => { 'type' => 'string',  'format' => 'date' },
+        'byte'      => { 'type' => 'string',  'format' => 'byte' },
         'date-time' => { 'type' => 'string',  'format' => 'date-time' },
+        'date'      => { 'type' => 'string',  'format' => 'date' },
+        'double'    => { 'type' => 'number',  'format' => 'double' },
+        'float'     => { 'type' => 'number',  'format' => 'float' },
+        'hash'      => { 'type' => 'object' },
+        'integer'   => { 'type' => 'integer', 'format' => 'int32' },
+        'long'      => { 'type' => 'integer', 'format' => 'int64' },
         'password'  => { 'type' => 'string',  'format' => 'password' },
-        'hash'      => { 'type' => 'object' }
+        'string'    => { 'type' => 'string' }
       }
 
       attr_reader :name
@@ -35,6 +35,10 @@ module Swaggard
         BASIC_TYPES.has_key?(@name.downcase)
       end
 
+      def custom_data_type?
+        Swaggard.configuration.custom_data_types.has_key?(@name.downcase)
+      end
+
       private
 
       def parse(types)
@@ -47,6 +51,8 @@ module Swaggard
       def type_tag_and_name
         if basic_type?
           BASIC_TYPES[@name.downcase]
+        elsif custom_data_type?
+          Swaggard.configuration.custom_data_types[@name.downcase]
         else
           { '$ref' => "#/definitions/#{name}" }
         end


### PR DESCRIPTION
Following on from my question regarding being able to [set UUIDs as a data type](https://github.com/adrian-gomez/swaggard/issues/34) I've got something 'working' which allows you to specify custom data types in the Swaggard config and use when generating the Swagger JSON output. 

Unfortunately the particular use case that I wanted this for doesn't work quite as expected, in that in Swagger UI it will still say `"id": "string"` in the examples because there is no uuid format (yet) in the Swagger spec but it does at least allow people to specify that it is a uuid in the seralizers using `@tag [uuid]` and outputs in the generated Swagger docs as:

```json
"id": {
  "type": "string",
  "format": "uuid"
}
```
Let me know your thoughts...