### PR TITLE
Clone obj before side effect

### DIFF
--- a/lib/swaggard/swagger/type.rb
+++ b/lib/swaggard/swagger/type.rb
@@ -46,7 +46,7 @@ module Swaggard
 
       def type_tag_and_name
         if basic_type?
-          BASIC_TYPES[@name.downcase]
+          BASIC_TYPES[@name.downcase].clone
         else
           { '$ref' => "#/definitions/#{name}" }
         end


### PR DESCRIPTION
Object in `BASIC_TYPE` is used without cloned.
If multiple parameters of same `basic_type`  (like `string` ) exists, `Swaggard::Swagger::Property#to_doc` will side-effect this same object repeatly.