### PR TITLE
Ensure the operationId is unique

### DIFF
--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -80,7 +80,7 @@ module Swaggard
       def to_doc
         {
           'tags'           => [@tag.name],
-          'operationId'    => @operation_id || @name,
+          'operationId'    => @operation_id || "#{@path}/#{@name}".parameterize,
           'summary'        => @summary,
           'description'    => @description,
           'produces'       => @formats.map { |format| "application/#{format}" },


### PR DESCRIPTION
When you have multiple routes to the same controller (nested) this
gives you the same operationIds but in different paths. This is not
valid.