### PR TITLE
Fix undefined methods

### DIFF
--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -94,6 +94,7 @@ module Swaggard
       def definitions
         @responses.map(&:definition).compact.inject({}) do |definitions, definition|
           definitions[definition.id] = definition
+          definitions
         end.tap do |definitions|
           next unless @body_parameter
 

--- a/lib/swaggard/swagger/response.rb
+++ b/lib/swaggard/swagger/response.rb
@@ -96,6 +96,9 @@ module Swaggard
           end
         end
 
+        def required?
+        end
+
         def response_class_type
           if PRIMITIVE_TYPES.include?(@response_class)
             { 'type' => @response_class }


### PR DESCRIPTION
1) In Operation `def definitions` was building a definitions hash by id, but not actually returning the hash for chaining. Resulting in error:
```
undefined method `[]=' for #<Swaggard::Swagger::Definition:0x00007feae308c048 @id="Api::V1::CustomersController.create_response", @title="", @properties=[#<Swaggard::Swagger::Response::ResponseModel:0x00007feae308c318 @is_array_response=nil, @response_class="CustomerSerializer", @id="customer">], @description="", @ancestors=[], @ignore_inherited=false>
```
2) In Definition `def to_doc` was selecting required properties, but `all_properties` contained a `ResponseModel` which didn't have a `required?` method.
```
undefined method `required?' for #<Swaggard::Swagger::Response::ResponseModel:0x00007fc65125fbb0 @is_array_response=nil, @response_class="CustomerSerializer", @id="customer">
```

Adding the missing `required?` method seemed cleaner than checking each for the presence of the method before calling it.
```
# existing
required_properties = all_properties.select(&:required?).map(&:id)
# meh
required_properties = all_properties.select { |p| p.respond_to?(:required?) && p.required? }.map(&:id)
```

On Ruby 3.0.6 / Rails 6.1.7.4