### PR TITLE
Fix @body_definition not generating requestBody in OpenAPI spec

### DIFF
--- a/lib/swaggard/swagger/parameters/body.rb
+++ b/lib/swaggard/swagger/parameters/body.rb
@@ -22,7 +22,7 @@ module Swaggard
         end
 
         def empty?
-          @definition.empty?
+          @definition.empty? && @definition_id == @definition.id
         end
 
         def to_request_body

--- a/spec/fixtures/api.json
+++ b/spec/fixtures/api.json
@@ -57,6 +57,30 @@
             "description": "successful operation"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "pets"
+        ],
+        "operationId": "create",
+        "summary": "create a new Pet",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PetBody"
+              }
+            }
+          }
+        }
       }
     },
     "/pets/{id}": {
@@ -105,6 +129,28 @@
             "description": "successful operation"
           }
         }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PetBody": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the Pet"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The age of the Pet"
+          }
+        }
+      },
+      "PetsController.create_body": {
+        "type": "object",
+        "properties": {}
       }
     }
   }

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -13,4 +13,11 @@ class PetsController < ApplicationController
   def show
   end
 
+  # create a new Pet
+  #
+  # @body_required
+  # @body_definition PetBody
+  def create
+  end
+
 end

--- a/spec/fixtures/dummy/app/serializers/pet_body.rb
+++ b/spec/fixtures/dummy/app/serializers/pet_body.rb
@@ -1,0 +1,3 @@
+# @attr [string] name The name of the Pet
+# @attr [integer] age The age of the Pet
+class PetBody; end

--- a/spec/fixtures/dummy/config/routes.rb
+++ b/spec/fixtures/dummy/config/routes.rb
@@ -1,6 +1,6 @@
 Dummy::Application.routes.draw do
 
-  resources :pets, only: [:index, :show]
+  resources :pets, only: [:index, :show, :create]
 
   namespace :admin do
     resources :pets, only: :index


### PR DESCRIPTION
## Problem

When using `@body_definition` to reference an external schema class (e.g. `@body_definition MySerializer`), the generated OpenAPI spec omits the `requestBody` entirely.

**Root cause:** The `definition=` setter in `Body` only updates `@definition_id` but leaves the internal `@definition` object (created in `initialize`) empty. When `to_doc` in `Operation` checks `body_param.empty?`, it delegates to `@definition.empty?` which returns `true` because the internal definition has no properties — even though an external schema reference was assigned.

## Fix

Update `empty?` to also check whether an external definition was assigned:

```ruby
def empty?
  @definition.empty? && @definition_id == @definition.id
end
```

This returns `false` when `@body_definition` has set a different `@definition_id`, allowing the `requestBody` with the correct `$ref` to be generated.

## Test

Added a `create` action to the dummy `PetsController` that uses `@body_definition PetBody`, along with a `PetBody` model class with `@attr` annotations. Both the integration fixture test and OAS 3.1 schema validation pass.

AI-assisted: Claude