### PR TITLE
Add @body_content_type YARD tag for non-JSON request bodies

### DIFF
--- a/lib/swaggard.rb
+++ b/lib/swaggard.rb
@@ -30,6 +30,7 @@ module Swaggard
       ::YARD::Tags::Library.define_tag('Body description', :body_description)
       ::YARD::Tags::Library.define_tag('Body title', :body_title)
       ::YARD::Tags::Library.define_tag('Body definition', :body_definition)
+      ::YARD::Tags::Library.define_tag('Body content type', :body_content_type)
       ::YARD::Tags::Library.define_tag('Body parameter', :body_parameter)
       ::YARD::Tags::Library.define_tag('Parameter list', :parameter_list)
       ::YARD::Tags::Library.define_tag('Response class', :response_class)

--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -44,6 +44,8 @@ module Swaggard
             body_parameter.title = value
           when 'body_definition'
             body_parameter.definition = value
+          when 'body_content_type'
+            body_parameter.content_type = value
           when 'body_parameter'
             body_parameter.add_property(value)
           when 'parameter_list'

--- a/lib/swaggard/swagger/parameters/body.rb
+++ b/lib/swaggard/swagger/parameters/body.rb
@@ -7,11 +7,14 @@ module Swaggard
       class Body < Base
         attr_reader :definition
 
+        attr_writer :content_type
+
         def initialize(operation_name)
           @in             = 'body'
           @name           = 'body'
           @is_required    = false
           @description    = ''
+          @content_type   = 'application/json'
           @definition     = Definition.new("#{operation_name}_body")
           @definition_id  = @definition.id
         end
@@ -29,7 +32,7 @@ module Swaggard
           {
             'required' => @is_required,
             'content'  => {
-              'application/json' => {
+              @content_type => {
                 'schema' => { '$ref' => "#/components/schemas/#{Swaggard.ref_name(@definition_id)}" }
               }
             }

--- a/lib/swaggard/version.rb
+++ b/lib/swaggard/version.rb
@@ -1,3 +1,3 @@
 module Swaggard
-  VERSION = '4.0.2'
+  VERSION = '4.0.3'
 end


### PR DESCRIPTION
\`Parameters::Body#to_request_body\` hardcoded \`application/json\` as the request body content-type. That's wrong for OpenAPI 3.x bodies that contain binary file fields — JSON can't carry raw bytes; the body needs \`multipart/form-data\`.

This adds a \`@body_content_type\` YARD tag so the controller author declares the content-type explicitly:

\`\`\`ruby
# @body_required
# @body_content_type multipart/form-data
# @body_parameter [binary]! file Some upload.
\`\`\`

## Changes

- **\`lib/swaggard.rb\`** — register the new \`body_content_type\` YARD tag.
- **\`lib/swaggard/swagger/operation.rb\`** — handle the tag, forwards the value to the body via the new writer.
- **\`lib/swaggard/swagger/parameters/body.rb\`** — \`Parameters::Body\` now stores \`@content_type\` (default \`application/json\`) and uses it in \`to_request_body\`.
- **\`lib/swaggard/version.rb\`** — bumps to \`4.0.3\`.

## Why a tag rather than auto-detection

I tried auto-picking multipart whenever any property was \`[binary]\` — that works but is implicit. An explicit tag is clearer at the call site, doesn't surprise authors who add a binary property later, and matches the rest of the \`@body_*\` family (\`@body_required\`, \`@body_title\`, \`@body_definition\`).

## Test plan

- [x] Existing \`spec/integration/\` specs pass (2 examples, 0 failures).
- [x] Verified against a real downstream consumer (hint-api): \`POST /partner/app/revisions\` now correctly emits \`multipart/form-data\` in built.json; JSON-body endpoints continue to emit \`application/json\`.

The downstream consumer references this commit via \`gem 'swaggard', git: '...', tag: 'v4.0.3'\` — tag will be re-applied to the merge commit once this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)