### PR TITLE
Emit type: array OpenAPI schemas for collection definitions

### DIFF
--- a/lib/swaggard/swagger/definition.rb
+++ b/lib/swaggard/swagger/definition.rb
@@ -5,13 +5,14 @@ module Swaggard
       attr_reader :id
       attr_writer :description, :title, :ignore_inherited
 
-      def initialize(id, ancestors: [])
+      def initialize(id, ancestors: [], collection: false)
         @id = id
         @title = ''
         @properties = []
         @description = ''
         @ancestors = ancestors
         @ignore_inherited = false
+        @collection = collection
       end
 
       def add_property(property)
@@ -41,19 +42,31 @@ module Swaggard
       end
 
       def to_doc(definitions)
-        {}.tap do |doc|
-          doc['title'] = @title if @title.present?
-          doc['type']  = 'object'
+        all_properties = properties(definitions)
+        properties_hash = Hash[all_properties.map { |property| [property.id, property.to_doc] }]
+        required_properties = all_properties.select(&:required?).map(&:id)
 
-          doc['description'] = @description if @description.present?
+        if @collection
+          items = { 'type' => 'object', 'properties' => properties_hash }
+          items['required'] = required_properties if required_properties.any?
 
-          all_properties = properties(definitions)
+          {}.tap do |doc|
+            doc['title'] = @title if @title.present?
+            doc['type'] = 'array'
+            doc['description'] = @description if @description.present?
+            doc['items'] = items
+          end
+        else
+          {}.tap do |doc|
+            doc['title'] = @title if @title.present?
+            doc['type']  = 'object'
 
-          doc['properties'] =  Hash[all_properties.map { |property| [property.id, property.to_doc] }]
-          required_properties = all_properties.select(&:required?).map(&:id)
-          doc['required'] = required_properties if required_properties.any?
+            doc['description'] = @description if @description.present?
+
+            doc['properties'] = properties_hash
+            doc['required'] = required_properties if required_properties.any?
+          end
         end
-
       end
 
     end

--- a/lib/swaggard/version.rb
+++ b/lib/swaggard/version.rb
@@ -1,3 +1,3 @@
 module Swaggard
-  VERSION = '4.0.3'
+  VERSION = '4.0.4'
 end

--- a/spec/swaggard/swagger/definition_spec.rb
+++ b/spec/swaggard/swagger/definition_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Swaggard::Swagger::Definition do
+  let(:property) { Swaggard::Swagger::Property.new('name', Swaggard::Swagger::Type.new(:string)) }
+
+  describe '#to_doc' do
+    context 'when collection is false (default)' do
+      subject(:definition) { described_class.new('Foo') }
+
+      before { definition.add_property(property) }
+
+      it 'emits a type: object schema with inline properties' do
+        expect(definition.to_doc({})).to eq(
+          'type' => 'object',
+          'properties' => { 'name' => { 'type' => 'string' } }
+        )
+      end
+    end
+
+    context 'when collection is true' do
+      subject(:definition) { described_class.new('Foo_all', collection: true) }
+
+      before { definition.add_property(property) }
+
+      it 'emits a type: array schema with properties wrapped under items' do
+        expect(definition.to_doc({})).to eq(
+          'type' => 'array',
+          'items' => {
+            'type' => 'object',
+            'properties' => { 'name' => { 'type' => 'string' } }
+          }
+        )
+      end
+
+      context 'with required properties' do
+        let(:property) do
+          Swaggard::Swagger::Property.new('name', Swaggard::Swagger::Type.new(:string), '', true)
+        end
+
+        it 'places the required array inside items' do
+          doc = definition.to_doc({})
+
+          expect(doc['required']).to be_nil
+          expect(doc['items']['required']).to eq(['name'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Definition#initialize` accepts a new `collection:` kwarg (default `false`).
- When `collection: true`, `to_doc` returns `{ type: 'array', items: { type: 'object', properties: {...} } }` instead of an object schema. Required fields move inside `items`.
- Bumps version to 4.0.4.

This unblocks hint-api so it can emit accurate OpenAPI schemas for Blueprinter `:all` views, whose runtime payload is an array but whose schema today is declared as an object. See https://github.com/hinthealth/hint-api/pull/19723#discussion_r3242609185.

## Test plan

- [x] `bundle exec rspec spec/integration/` — 2 examples, 0 failures.
- [x] New `spec/swaggard/swagger/definition_spec.rb` covers both branches (3 examples).