### PR TITLE
Add deprecated marker support for properties and body parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Add YARD comments to provide richer documentation:
 
 - `@tag name` — Group this controller under `name`. Defaults to the controller path if `ignore_untagged_controllers` is false.
 - `@query_parameter [type] name` — Query string parameter.
-- `@body_parameter [type] name` — Request body property. Generates a `requestBody` in the OpenAPI output.
+- `@body_parameter [type] name` — Request body property. Generates a `requestBody` in the OpenAPI output. Use `[type]!` to mark the property as required and `name(deprecated)` to mark it as deprecated.
 - `@form_parameter [type] name` — Form data parameter (`application/x-www-form-urlencoded`).
 - `@parameter_list` — Enum-style query parameter list.
 - `@response_class type` — Response schema type. Supports `Array<Type>` for array responses.
@@ -162,7 +162,7 @@ To document all controllers including those without a `@tag`:
 
 ### Models
 
-- `@attr [type] name` — Model attribute.
+- `@attr [type] name` — Model attribute. Use `!name` to mark the attribute as required and `name(deprecated)` to mark it as deprecated.
 - `@ignore_inherited` — Do not inherit properties from parent class.
 
 

--- a/lib/swaggard/parsers/property.rb
+++ b/lib/swaggard/parsers/property.rb
@@ -11,10 +11,11 @@ module Swaggard
         options, description = options_and_description.match(/\A(\[.*\])?(.*)\Z/).captures
         options = options ? options.gsub(/\[?\]?\s?/, '').split(',') : []
         description = description.strip
+        deprecated = name.gsub!(/\(deprecated\)\z/, '')
         required = name.gsub!(/^!/, '')
         type = Parsers::Type.run(yard_object.types.first)
 
-        Swaggard::Swagger::Property.new(name, type, description, required.present?, options)
+        Swaggard::Swagger::Property.new(name, type, description, required.present?, options, deprecated.present?)
       end
     end
   end

--- a/lib/swaggard/swagger/parameters/body.rb
+++ b/lib/swaggard/swagger/parameters/body.rb
@@ -72,15 +72,17 @@ module Swaggard
             elsif @options.present?
               result['enum'] = @options
             end
+            result['deprecated'] = true if @deprecated
             result
           end
 
           # Example: [Array]     status            Filter by status. (e.g. status[]=1&status[]=2&status[]=3)
           # Example: [Array]     status(required)  Filter by status. (e.g. status[]=1&status[]=2&status[]=3)
           # Example: [Integer]   media[media_type_id]                          ID of the desired media type.
+          # Example: [Boolean]   uses_tobacco(deprecated)  Whether the patient uses tobacco.
           def parse(string)
             string.gsub!("\n", ' ')
-            data_type, required, name, options_and_description = string.match(/\A\[(\S*)\](!)?\s*([\w\[\]]*)\s*(.*)\Z/).captures
+            data_type, required, name, deprecated, options_and_description = string.match(/\A\[(\S*)\](!)?\s*([\w\[\]]*)(\(deprecated\))?\s*(.*)\Z/).captures
             options, description = options_and_description.match(/\A(\[.*\])?(.*)\Z/).captures
             options = options ? options.gsub(/\[?\]?\s?/, '').split(',') : []
 
@@ -89,6 +91,7 @@ module Swaggard
             @type = Parsers::Type.run(data_type)
             @required = required
             @options = options
+            @deprecated = deprecated.present?
           end
         end
       end

--- a/lib/swaggard/swagger/property.rb
+++ b/lib/swaggard/swagger/property.rb
@@ -5,22 +5,28 @@ module Swaggard
     class Property
       attr_reader :id, :type, :description
 
-      def initialize(name, type, description = '', required = false, options = [])
+      def initialize(name, type, description = '', required = false, options = [], deprecated = false)
         @id = name
         @type = type
         @description = description
         @required = required
         @options = options
+        @deprecated = deprecated
       end
 
       def required?
         @required
       end
 
+      def deprecated?
+        @deprecated
+      end
+
       def to_doc
         result = @type.to_doc
         result['description'] = @description if @description.present?
         result['enum'] = @options if @options.present?
+        result['deprecated'] = true if @deprecated
         result
       end
     end

--- a/lib/swaggard/version.rb
+++ b/lib/swaggard/version.rb
@@ -1,3 +1,3 @@
 module Swaggard
-  VERSION = '4.0.4'
+  VERSION = '4.1.0'
 end

--- a/spec/swaggard/parsers/property_spec.rb
+++ b/spec/swaggard/parsers/property_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Swaggard::Parsers::Property do
+  def yard_tag(name, text: 'A description', types: ['string'])
+    YARD::Tags::Tag.new('attr', text, types, name)
+  end
+
+  describe '.run' do
+    it 'parses a plain attribute' do
+      property = described_class.run(yard_tag('name'))
+
+      expect(property.id).to eq('name')
+      expect(property).not_to be_required
+      expect(property).not_to be_deprecated
+    end
+
+    it 'parses the required marker' do
+      property = described_class.run(yard_tag('!name'))
+
+      expect(property.id).to eq('name')
+      expect(property).to be_required
+    end
+
+    it 'parses the deprecated marker' do
+      property = described_class.run(yard_tag('uses_tobacco(deprecated)', types: ['boolean']))
+
+      expect(property.id).to eq('uses_tobacco')
+      expect(property).to be_deprecated
+      expect(property.to_doc).to include('deprecated' => true)
+    end
+
+    it 'combines the required and deprecated markers' do
+      property = described_class.run(yard_tag('!name(deprecated)'))
+
+      expect(property.id).to eq('name')
+      expect(property).to be_required
+      expect(property).to be_deprecated
+    end
+  end
+end

--- a/spec/swaggard/swagger/parameters/body_spec.rb
+++ b/spec/swaggard/swagger/parameters/body_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Swaggard::Swagger::Parameters::Body do
+  subject(:body) { described_class.new('PetsController.create') }
+
+  def property_doc(name)
+    body.definition.to_doc({})['properties'][name]
+  end
+
+  describe '#add_property' do
+    it 'parses type, name and description' do
+      body.add_property('[String] name The name of the pet')
+
+      expect(property_doc('name')).to eq('type' => 'string', 'description' => 'The name of the pet')
+    end
+
+    it 'parses the required marker' do
+      body.add_property('[String]! name The name of the pet')
+
+      expect(body.definition.to_doc({})['required']).to eq(['name'])
+    end
+
+    it 'parses the deprecated marker' do
+      body.add_property('[Boolean] uses_tobacco(deprecated) Use lifestyle instead.')
+
+      expect(property_doc('uses_tobacco')).to eq(
+        'type' => 'boolean',
+        'description' => 'Use lifestyle instead.',
+        'deprecated' => true
+      )
+    end
+
+    it 'combines the required and deprecated markers' do
+      body.add_property('[String]! name(deprecated) The name of the pet')
+
+      expect(property_doc('name')['deprecated']).to be(true)
+      expect(body.definition.to_doc({})['required']).to eq(['name'])
+    end
+
+    it 'keeps enum options working alongside the deprecated marker' do
+      body.add_property('[String] status(deprecated) [active,inactive] The status')
+
+      expect(property_doc('status')).to eq(
+        'type' => 'string',
+        'description' => ' The status',
+        'enum' => %w[active inactive],
+        'deprecated' => true
+      )
+    end
+  end
+end

--- a/spec/swaggard/swagger/property_spec.rb
+++ b/spec/swaggard/swagger/property_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Swaggard::Swagger::Property do
+  describe '#to_doc' do
+    let(:type) { Swaggard::Swagger::Type.new(:string) }
+
+    it 'emits the type only by default' do
+      property = described_class.new('name', type)
+
+      expect(property.to_doc).to eq('type' => 'string')
+    end
+
+    it 'emits the description when present' do
+      property = described_class.new('name', type, 'The full name')
+
+      expect(property.to_doc).to eq('type' => 'string', 'description' => 'The full name')
+    end
+
+    it 'emits deprecated when the property is deprecated' do
+      property = described_class.new('name', type, '', false, [], true)
+
+      expect(property.to_doc).to eq('type' => 'string', 'deprecated' => true)
+      expect(property).to be_deprecated
+    end
+
+    it 'does not emit deprecated when the property is not deprecated' do
+      property = described_class.new('name', type)
+
+      expect(property.to_doc).not_to have_key('deprecated')
+      expect(property).not_to be_deprecated
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `Swagger::Property` accepts a `deprecated` flag and emits `deprecated: true` in the OpenAPI property schema.
- The `@body_parameter` and `@attr` parsers recognize a `name(deprecated)` suffix (composable with the `!` required marker) to set that flag on request body properties and model attributes.
- Bumps the version to 4.1.0. Note for release: 4.0.4 was published before the `type: array` collection schemas and `@body_content_type` commits on master, so this release also picks those up.

## Usage

```ruby
# @body_parameter [Boolean] uses_tobacco(deprecated) Use lifestyle instead.

# @attr [string] !name(deprecated)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
