### PR TITLE
Strip only the leading base path from documented paths

### DIFF
--- a/lib/swaggard/api_definition.rb
+++ b/lib/swaggard/api_definition.rb
@@ -66,7 +66,9 @@ module Swaggard
     def format_path(path)
       return path unless Swaggard.configuration.exclude_base_path_from_paths
 
-      path.gsub(Swaggard.configuration.api_base_path, '')
+      base_path = Swaggard.configuration.api_base_path
+
+      path.sub(/\A#{Regexp.escape(base_path)}/, '')
     end
 
     def build_components

--- a/spec/swaggard/api_definition_spec.rb
+++ b/spec/swaggard/api_definition_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Swaggard::ApiDefinition do
+  describe '#format_path' do
+    subject(:formatted) { described_class.new.send(:format_path, path) }
+
+    let(:original_base_path) { Swaggard.configuration.api_base_path }
+    let(:original_exclude)   { Swaggard.configuration.exclude_base_path_from_paths }
+
+    before do
+      original_base_path
+      original_exclude
+      Swaggard.configuration.api_base_path = '/api'
+      Swaggard.configuration.exclude_base_path_from_paths = true
+    end
+
+    after do
+      Swaggard.configuration.api_base_path = original_base_path
+      Swaggard.configuration.exclude_base_path_from_paths = original_exclude
+    end
+
+    context 'when the base path also appears inside a later path segment' do
+      let(:path) { '/api/partner/api_keys' }
+
+      it 'strips only the leading base path, not every occurrence' do
+        expect(formatted).to eq('/partner/api_keys')
+      end
+    end
+
+    context 'with a path that only contains the leading base path' do
+      let(:path) { '/api/partner/products' }
+
+      it 'strips the leading base path' do
+        expect(formatted).to eq('/partner/products')
+      end
+    end
+
+    context 'when exclude_base_path_from_paths is disabled' do
+      let(:path) { '/api/partner/api_keys' }
+
+      before { Swaggard.configuration.exclude_base_path_from_paths = false }
+
+      it 'returns the path unchanged' do
+        expect(formatted).to eq('/api/partner/api_keys')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`exclude_base_path_from_paths` strips the base path from documented paths with `String#gsub`:

```ruby
path.gsub(Swaggard.configuration.api_base_path, '')
```

`gsub` removes **every** occurrence of the base-path substring, not just the leading prefix. When a route segment also contains the base path, the inner occurrence is stripped too.

With base path `/api` and route `/api/partner/api_keys`, both `/api` substrings (the leading prefix and the one inside `/api_keys`) are removed, collapsing the documented path to:

```
/partner_keys      # expected: /partner/api_keys
```

Any route whose path contains the base path as an internal substring is affected.

## Fix

Strip only the leading base path with an anchored `sub`:

```ruby
base_path = Swaggard.configuration.api_base_path
path.sub(/\A#{Regexp.escape(base_path)}/, '')
```

`Regexp.escape` keeps base paths with regex-special characters safe.

## Tests

Added `spec/swaggard/api_definition_spec.rb` covering `#format_path`:
- base path appearing inside a later segment (`/api/partner/api_keys` → `/partner/api_keys`)
- the ordinary leading-prefix case
- the disabled (`exclude_base_path_from_paths = false`) pass-through

Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
