### PR TITLE
Add @deprecated operation tag

### DIFF
--- a/lib/swaggard.rb
+++ b/lib/swaggard.rb
@@ -24,6 +24,7 @@ module Swaggard
     def register_custom_yard_tags!
       ::YARD::Tags::Library.define_tag('Controller\'s tag', :tag)
       ::YARD::Tags::Library.define_tag('Operation id', :operation_id)
+      ::YARD::Tags::Library.define_tag('Deprecated', :deprecated)
       ::YARD::Tags::Library.define_tag('Query parameter', :query_parameter)
       ::YARD::Tags::Library.define_tag('Form parameter', :form_parameter)
       ::YARD::Tags::Library.define_tag('Body required', :body_required)

--- a/lib/swaggard/swagger/operation.rb
+++ b/lib/swaggard/swagger/operation.rb
@@ -19,6 +19,7 @@ module Swaggard
         @summary = (yard_object.docstring.lines.first || '').chomp
         @parameters  = []
         @responses = []
+        @deprecated = false
 
         @description = (yard_object.docstring.lines[1..-1] || []).map(&:chomp).reject(&:empty?).compact.join("\n")
         @http_method = verb
@@ -32,6 +33,8 @@ module Swaggard
           case yard_tag.tag_name
           when 'operation_id'
             @operation_id = "#{@tag.name}.#{value}"
+          when 'deprecated'
+            @deprecated = true
           when 'query_parameter'
             @parameters << Parameters::Query.new(value)
           when 'form_parameter'
@@ -97,6 +100,8 @@ module Swaggard
         elsif form_params.any?
           doc['requestBody'] = build_form_request_body(form_params)
         end
+
+        doc['deprecated'] = true if @deprecated
 
         doc
       end

--- a/lib/swaggard/version.rb
+++ b/lib/swaggard/version.rb
@@ -1,3 +1,3 @@
 module Swaggard
-  VERSION = '4.1.1'
+  VERSION = '4.2.0'
 end

--- a/spec/fixtures/api.json
+++ b/spec/fixtures/api.json
@@ -80,7 +80,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/pets/{id}": {

--- a/spec/fixtures/dummy/app/controllers/pets_controller.rb
+++ b/spec/fixtures/dummy/app/controllers/pets_controller.rb
@@ -15,6 +15,7 @@ class PetsController < ApplicationController
 
   # create a new Pet
   #
+  # @deprecated
   # @body_required
   # @body_definition PetBody
   def create


### PR DESCRIPTION
Adds support for a `# @deprecated` YARD tag on controller actions. When present, the generated OpenAPI doc emits `deprecated: true` on that operation — valid in both Swagger 2.0 and OpenAPI 3.x — so doc renderers (ReadMe, Swagger UI) show a deprecation badge without the endpoint being removed.

## Usage

```ruby
# Exchange an authorization code for a token
#
# @deprecated
# @operation_id ExchangeToken
def create
end
```

→ `paths./oauth/tokens.post.deprecated = true`

## Changes

- Register the `:deprecated` YARD tag (`register_custom_yard_tags!`).
- Parse it in `Swagger::Operation` and emit `doc['deprecated'] = true` in `to_doc`.
- Cover it via the dummy `PetsController#create` and the `api.json` fixture; the OAS 3.1 schema-validation spec confirms the flag is schema-valid.
- Version 4.1.1 → 4.2.0 (additive feature, backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)